### PR TITLE
リストに戻った際に毎回リフレッシュが走らないようにする 

### DIFF
--- a/app/src/main/java/com/example/qiitaviewerandroid/fragment/ArticleListFragment.kt
+++ b/app/src/main/java/com/example/qiitaviewerandroid/fragment/ArticleListFragment.kt
@@ -78,13 +78,12 @@ class ArticleListFragment : Fragment() {
 
         binding.articleListRecyclerview.adapter = adapter
 
-        search()
-
         return binding.root
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        search()
         setHasOptionsMenu(true)
     }
 


### PR DESCRIPTION
#27 
初回のsearchの発火をonCreateView -> onCreateに変更した